### PR TITLE
Add support for Shaka Player

### DIFF
--- a/player_embedder.css
+++ b/player_embedder.css
@@ -1,0 +1,17 @@
+.player_embedder-overlay{
+    position: absolute;
+    z-index: 2147483647;
+    background-color: rgba(0,0,0,0);
+}
+.player_embedder-overlay p{
+    color: #FFF;
+    text-align: center;
+    font-size: 1.5em;
+    background-color: rgba(221, 221, 221, 0.3);
+    padding-left: 5%;
+    padding-right: 5%;
+}
+
+.player_embedder-video{
+    z-index: 1;
+}

--- a/player_embedder.css
+++ b/player_embedder.css
@@ -5,7 +5,8 @@
 }
 .player_embedder-overlay-content{
     text-align: center;
-    background-color: rgba(221, 221, 221, 0.3);
+    background-color: rgba(0, 0, 0, 0.32);
+    padding-bottom: 4px;
 }
 
 .player_embedder-overlay p{

--- a/player_embedder.css
+++ b/player_embedder.css
@@ -3,11 +3,14 @@
     z-index: 2147483647;
     background-color: rgba(0,0,0,0);
 }
+.player_embedder-overlay-content{
+    text-align: center;
+    background-color: rgba(221, 221, 221, 0.3);
+}
+
 .player_embedder-overlay p{
     color: #FFF;
-    text-align: center;
     font-size: 1.5em;
-    background-color: rgba(221, 221, 221, 0.3);
     padding-left: 5%;
     padding-right: 5%;
 }

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -384,7 +384,7 @@
             var self = playerEmbedder,
                 vidtag = $("video", data.container);
             if (vidtag.length == 0){
-                vidtag = $('<video></video>');
+                vidtag = $('<video autoplay></video>');
                 data.container.append(vidtag);
             }
             vidtag.attr('id', data.playerId);

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -391,6 +391,9 @@
                 player = new shaka.player.Player(vidtag.get(0));
                 estimator = new shaka.util.EWMABandwidthEstimator();
                 source = new shaka.player.DashVideoSource(data.streamSrc.mpd_url, null, estimator);
+                player.addEventListener('error', function(e){
+                    data.container.trigger('player_error', [player, e]);
+                });
                 player.load(source);
                 data.player = player;
                 data.container.trigger('player_embed_complete');

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -26,8 +26,6 @@
         },
         debugMode: false,
         debugOutputFunction: null,
-        debugSaveDataEnable: false,
-        debugData: [],
         debug: function(){
             if (!this.debugMode){
                 return;
@@ -39,13 +37,10 @@
             $.each(arguments, function(i, arg){
                 args.push(arg);
             });
-            if (this.debugOutputFunction == 'console'){
-                console.log(args);
-            } else if (this.debugOutputFunction){
+            if (this.debugOutputFunction){
                 this.debugOutputFunction(args);
-            }
-            if (this.debugSaveDataEnable){
-                this.debugData.push(args);
+            } else {
+                console.log(args);
             }
         },
         formatLibUrl: function(url){
@@ -402,11 +397,7 @@
                     playerWrapper.append(player);
                     data.container.append(playerWrapper);
                     self.debug('static content built... registering with swfobject');
-                    try {
-                        swfobject.registerObject(data.playerId, flashVars.minimumFlashPlayerVersion);
-                    } catch(e) {
-                        self.debug('swfobject error: ', e);
-                    }
+                    swfobject.registerObject(data.playerId, flashVars.minimumFlashPlayerVersion);
                 },
                 embedDynamic = function(playerWrapper){
                     self.debug('embedding using dynamic method');
@@ -415,11 +406,7 @@
                     player.append(self.buildFallbackContent(data));
                     playerWrapper.append(player);
                     data.container.append(playerWrapper);
-                    try {
-                        swfobject.embedSWF.apply(swfobject.embedSWF, embedData);
-                    } catch(e) {
-                        self.debug('swfobject error: ', e);
-                    }
+                    swfobject.embedSWF.apply(swfobject.embedSWF, embedData);
                 };
             $.each(embedDataKeys, function(i, key){
                 var val = flashVars[key];
@@ -435,19 +422,12 @@
                     flashVer,
                     flashVerStr = [];
                 self.debug('testing Flash version...');
-                try {
-                    flashVer = swfobject.getFlashPlayerVersion();
-                } catch(e) {
-                    self.debug('Flash detection error: ', e);
-                    flashVer = null;
-                }
-                if (flashVer){
-                    $.each(['major', 'minor', 'release'], function(i, n){
-                        flashVerStr.push(flashVer[n].toString());
-                    });
-                    flashVerStr = flashVerStr.join('.');
-                    self.debug('Flash version: ', flashVerStr);
-                }
+                flashVer = swfobject.getFlashPlayerVersion(),
+                $.each(['major', 'minor', 'release'], function(i, n){
+                    flashVerStr.push(flashVer[n].toString());
+                });
+                flashVerStr = flashVerStr.join('.');
+                self.debug('Flash version: ', flashVerStr);
                 self.addPlayerClasses(playerWrapper, data);
                 if (navigator.userAgent.search('PLAYSTATION') != -1){
                     embedStatic(playerWrapper);

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -422,7 +422,7 @@
                     flashVer,
                     flashVerStr = [];
                 self.debug('testing Flash version...');
-                flashVer = swfobject.getFlashPlayerVersion(),
+                flashVer = swfobject.getFlashPlayerVersion();
                 $.each(['major', 'minor', 'release'], function(i, n){
                     flashVerStr.push(flashVer[n].toString());
                 });

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -49,10 +49,10 @@
             }
         },
         formatLibUrl: function(url){
-            var self = this;
-            var replTxt = null;
-            var lib = null;
-            var libUrl = null;
+            var self = this,
+                replTxt,
+                lib,
+                libUrl;
             if (url.indexOf('_ROOTURL_') == -1){
                 return url;
             }
@@ -62,10 +62,10 @@
             return url.replace(replTxt, libUrl);
         },
         loadSources: function(libName){
-            var self = this;
-            var cssComplete = false;
-            var scriptsComplete = false;
-            var loadedSources = $("body").data('player_embedder_sources_loaded');
+            var self = this,
+                cssComplete = false,
+                scriptsComplete = false,
+                loadedSources = $("body").data('player_embedder_sources_loaded');
             self.debug('loading sources');
             if (typeof(loadedSources) == 'undefined'){
                 loadedSources = {};
@@ -74,8 +74,8 @@
                 self.debug('sources already loaded: ', loadedSources);
             }
             function loadCss(){
-                var numResponse = 0;
-                var urls = self.cssUrls[libName];
+                var numResponse = 0,
+                    urls = self.cssUrls[libName];
                 if (!urls || urls.length == 0){
                     $("body").trigger('player_embedder_css_loaded');
                     return;
@@ -98,8 +98,8 @@
                 });
             }
             function loadJs(){
-                var numResponse = 0;
-                var urls = self.scriptUrls[libName];
+                var numResponse = 0,
+                    urls = self.scriptUrls[libName];
                 if (!urls || urls.length == 0){
                     $("body").trigger('player_embedder_scripts_loaded');
                     return;
@@ -145,11 +145,12 @@
             loadJs();
         },
         streamSrc: function(base_url){
-                var d = {};
-                d.base_url = base_url
-                d.hls_url = [base_url, 'playlist.m3u8'].join('/')
-                d.hds_url = [base_url, 'manifest.f4m'].join('/')
-                return d;
+            var d = {
+              base_url: base_url,
+              hls_url: [base_url, 'playlist.m3u8'].join('/'),
+              hds_url: [base_url, 'manifest.f4m'].join('/'),
+            };
+            return d;
         },
         embedDataDefaults: {
             streamSrc: '',
@@ -166,7 +167,7 @@
             expressInstallSwfUrl: '_ROOTURL_STROBE_/expressInstall.swf',
         },
         embedData: function(data){
-            d = {}
+            var d = {};
             $.each(playerEmbedder.embedDataDefaults, function(key, val){
                 if (typeof(data[key]) != 'undefined'){
                     val = data[key];
@@ -253,8 +254,8 @@
             return result;
         },
         doEmbed: function(data){
-            var self = this;
-            var embed_fn = null;
+            var self = this,
+                embed_fn;
             if (typeof(data) == 'string'){
                 data = {'streamSrc':data};
             }
@@ -295,8 +296,8 @@
             return data;
         },
         doEmbed_html5: function(data){
-            var self = playerEmbedder;
-            var vidtag = $("video", data.container);
+            var self = playerEmbedder,
+                vidtag = $("video", data.container);
             if (vidtag.length == 0){
                 vidtag = $('<video></video>');
                 data.container.append(vidtag);
@@ -322,14 +323,14 @@
         doEmbed_videojs: function(data){
             var self = playerEmbedder;
             $("body").one('player_embedder_sources_loaded', function(){
-                var vidtag = $("video", data.container);
-                var opts = {
-                    'controls': true,
-                    'autoplay': true,
-                    'width':data.size[0],
-                    'height':data.size[1],
-                    'nativeControlsForTouch': false,
-                };
+                var vidtag = $("video", data.container),
+                    opts = {
+                      'controls': true,
+                      'autoplay': true,
+                      'width':data.size[0],
+                      'height':data.size[1],
+                      'nativeControlsForTouch': false,
+                    };
                 if (vidtag.length == 0){
                     vidtag = $('<video></video>');
                     data.container.append(vidtag);
@@ -376,7 +377,7 @@
                         data.player = $("#" + event.id);
                     }
                     data.container.trigger('player_embed_complete');
-                };
+                },
                 embedStatic = function(playerWrapper){
                     self.debug('embedding using static method (PS3)');
                     var player = $('<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"></object>'),
@@ -460,9 +461,9 @@
             return data;
         },
         doResize: function(container, newSize){
-            var self = this;
-            var data = container.data('embedData');
-            var resizeFn = playerEmbedder['doResize_' + data.embed_method];
+            var self = this,
+                data = container.data('embedData'),
+                resizeFn = playerEmbedder['doResize_' + data.embed_method];
             if (data.sizeByCSS == true){
                 return;
             }
@@ -504,12 +505,12 @@
                 }
                 return width;
             }
-            var complete = null;
-            var hasChanged = false;
-            var x = getMaxWidth();
-            var xMin = x * 0.5;
-            var y = null;
-            var ratio = data.aspect_ratio[0] / data.aspect_ratio[1];
+            var complete,
+                hasChanged = false,
+                x = getMaxWidth(),
+                xMin = x * 0.5,
+                y,
+                ratio = data.aspect_ratio[0] / data.aspect_ratio[1];
             if (data.sizeWithContainer == true){
                 x = data.container.innerWidth();
                 y = data.container.innerHeight();
@@ -521,7 +522,7 @@
                     data.size[1] = y;
                     return true;
                 } else {
-                    data.size = [x, y]
+                    data.size = [x, y];
                     return true;
                 }
             }

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -1,24 +1,16 @@
 (function($){
     var playerEmbedder = {
-        embed_methods: ['auto', 'html5', 'shaka', 'videojs', 'strobe'],
+        embed_methods: ['auto', 'html5', 'shaka', 'strobe'],
         html5_embed_method: 'html5',
         libRootUrls: {
-            'videojs':'/videojs',
             'strobe':'/strobe-media',
         },
         cssUrls: {
-            'videojs':[
-                '//vjs.zencdn.net/4.5/video-js.css',
-            ],
             //'strobe':[
                 //'_ROOTURL_STROBE_/jquery.strobemediaplayback.css',
             //],
         },
         scriptUrls: {
-            'videojs':[
-                '//vjs.zencdn.net/4.5/video.js',
-                //'_ROOTURL_VIDEOJS_/videojs.hls.min.js',
-            ],
             'strobe':[
                 '//ajax.googleapis.com/ajax/libs/swfobject/2.2/swfobject.js',
                 //'_ROOTURL_STROBE_/jquery.strobemediaplayback.js',
@@ -362,9 +354,8 @@
                 embed_fn,
                 dfd = $.Deferred();
             if (hlsSupported){
-                data.embed_method = self.html5_embed_method;
-                embed_fn = self['doEmbed_' + data.embed_method];
-                data = embed_fn(data);
+                data.embed_method = 'html5'
+                data = self.doEmbed_html5(data);
                 dfd.resolve(data);
             } else {
                 self.testMPDSupport(data).done(function(){
@@ -434,33 +425,6 @@
                 doEmbed(data);
             });
             return dfd.promise();
-        },
-        doEmbed_videojs: function(data){
-            var self = playerEmbedder;
-            $("body").one('player_embedder_sources_loaded', function(){
-                var vidtag = $("video", data.container),
-                    opts = {
-                      'controls': true,
-                      'autoplay': true,
-                      'width':data.size[0],
-                      'height':data.size[1],
-                      'nativeControlsForTouch': false,
-                    };
-                if (vidtag.length == 0){
-                    vidtag = $('<video></video>');
-                    data.container.append(vidtag);
-                }
-                self.addPlayerClasses(vidtag, data);
-                vidtag.addClass('video-js vjs-default-skin');
-                vidtag.attr('id', data.playerId);
-                vidtag.append('<source src="URL" type="application/vnd.apple.mpegurl">'.replace('URL', data.streamSrc.hls_url));
-                videojs(data.playerId, opts, function(){
-                    data.player = this;
-                    data.container.trigger('player_embed_complete');
-                });
-            });
-            self.loadSources('videojs');
-            return data
         },
         doEmbed_strobe: function(data){
             var self = playerEmbedder,

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -80,7 +80,7 @@
                 var numResponse = 0,
                     urls = self.cssUrls[libName];
                 if (!urls || urls.length == 0){
-                    $("body").trigger('player_embedder_css_loaded');
+                    $("body").trigger('player_embedder_css_loaded', [libName]);
                     return;
                 }
                 self.debug('loading css');
@@ -95,7 +95,7 @@
                         $("body").append(s);
                         numResponse += 1;
                         if (numResponse == urls.length){
-                            $("body").trigger('player_embedder_css_loaded');
+                            $("body").trigger('player_embedder_css_loaded', [libName]);
                         }
                     });
                 });
@@ -104,7 +104,7 @@
                 var numResponse = 0,
                     urls = self.scriptUrls[libName];
                 if (!urls || urls.length == 0){
-                    $("body").trigger('player_embedder_scripts_loaded');
+                    $("body").trigger('player_embedder_scripts_loaded', [libName]);
                     return;
                 }
                 self.debug('loading js');
@@ -116,7 +116,7 @@
                     $.getScript(url, function(){
                         numResponse += 1;
                         if (numResponse == urls.length){
-                            $("body").trigger('player_embedder_scripts_loaded');
+                            $("body").trigger('player_embedder_scripts_loaded', [libName]);
                         }
                     });
                 });
@@ -125,7 +125,7 @@
                 loadedSources[libName] = true;
                 if (cssComplete && scriptsComplete){
                     self.debug('all sources loaded');
-                    $("body").trigger('player_embedder_sources_loaded');
+                    $("body").trigger('player_embedder_sources_loaded', [libName]);
                 }
             }
             if (loadedSources[libName]){

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -288,7 +288,7 @@
         testHLSSupport: function(data){
             this.debug('testing HLS capabilities');
             var result = false,
-                vidtag = $('<video></video>');
+                vidtag = $('<video autoplay></video>');
             try {
                 data.container.append(vidtag);
                 if (vidtag[0].canPlayType('application/vnd.apple.mpegurl') != ''){
@@ -602,9 +602,10 @@
             data.player.width(data.size[0]);
             data.player.height(data.size[1]);
         },
-        doResize_videojs: function(data){
-            data.player.width(data.size[0]);
-            data.player.height(data.size[1]);
+        doResize_shaka: function(data){
+            var player = $("#" + data.playerId);
+            player.width(data.size[0]);
+            player.height(data.size[1]);
         },
         doResize_strobe: function(data){
             // need to look at api docs

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -405,14 +405,24 @@
         },
         showOverlayMessage: function(data, message){
             var vidtag = $("video", data.container),
-                overlay = data.overlay;
+                overlay = data.overlay,
+                $content;
+            if (message.jquery){
+                $content = message;
+            } else {
+                $content = $('<p>' + message + '</p>');
+            }
+            $content.addClass('player_embedder-overlay-content');
             overlay
                 .empty()
-                .append('<p>' + message + '</p>')
+                .append($content)
                 .innerWidth(data.container.innerWidth())
                 .innerHeight(data.container.innerHeight())
                 .css(vidtag.position())
-                .show();
+                .show()
+                .click(function(){
+                    $content.parent().hide();
+                });
         },
         hideOverlay: function(){
             $(".player_embedder-overlay").hide();

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -151,7 +151,8 @@
             return dfd.promise();
         },
         loadShakaSources: function(){
-            var dfd = $.Deferred();
+            var dfd = $.Deferred(),
+                startTime = new Date();
             function isShakaLoaded(){
                 var loadedSources = $("body").data('player_embedder_sources_loaded');
                 if ($("body").data('shakaSourcesLoaded')){
@@ -175,11 +176,14 @@
                 dfd.resolve();
             }
             function waitForShaka(){
-                if (isShakaLoaded()){
+                var now = new Date();
+                if (now - startTime > 10000){
+                    dfd.reject();
+                } else if (isShakaLoaded()){
                     initShaka();
                 } else {
                     console.log('waiting for shaka');
-                    window.setTimeout(waitForShaka, 10);
+                    window.setTimeout(waitForShaka, 100);
                 }
             }
             if (isShakaLoaded()){

--- a/player_embedder.js
+++ b/player_embedder.js
@@ -362,8 +362,9 @@
                 dfd = $.Deferred();
             if (hlsSupported){
                 data.embed_method = 'html5'
-                data = self.doEmbed_html5(data);
-                dfd.resolve(data);
+                self.doEmbed_html5(data).done(function(data){
+                    dfd.resolve(data);
+                });
             } else {
                 self.testMPDSupport(data).done(function(){
                     data.embed_method = 'shaka';
@@ -372,8 +373,9 @@
                     });
                 }).fail(function(){
                     data.embed_method = 'strobe';
-                    data = self.doEmbed_strobe(data);
-                    dfd.resolve(data);
+                    self.doEmbed_strobe(data).done(function(data){
+                        dfd.resolve(data);
+                    });
                 });
             }
             return dfd.promise();
@@ -429,7 +431,8 @@
         },
         doEmbed_html5: function(data){
             var self = playerEmbedder,
-                vidtag = self.buildVidTag(data);
+                vidtag = self.buildVidTag(data),
+                dfd = $.Deferred();
             vidtag.append('<source src="URL" type="application/vnd.apple.mpegurl">'.replace('URL', data.streamSrc.hls_url));
             data.player = vidtag;
             fbdiv = self.buildFallbackContent(data);
@@ -437,7 +440,8 @@
                 data.container.parent().append(fbdiv);
             }
             data.container.trigger('player_embed_complete');
-            return data;
+            dfd.resolve(data);
+            return dfd.promise();
         },
         doEmbed_shaka: function(data){
             var dfd = $.Deferred();
@@ -474,6 +478,7 @@
         },
         doEmbed_strobe: function(data){
             var self = playerEmbedder,
+                dfd = $.Deferred(),
                 embedDataKeys = ['swf', 'id', 'width', 'height', 'minimumFlashPlayerVersion', 'expressInstallSwfUrl'],
                 embedData = [],
                 flashVars = {
@@ -580,10 +585,11 @@
                 } else {
                     embedDynamic(playerWrapper);
                 }
+                dfd.resolve(data);
             });
             self.debug('loading strobe sources');
             self.loadSources('strobe');
-            return data;
+            return dfd.promise();
         },
         doResize: function(container, newSize){
             var self = this,


### PR DESCRIPTION
Uses [Shaka Player](https://github.com/google/shaka-player) for MPEG-DASH playback if available, leaving Strobe (OSMF) as the final fallback.
